### PR TITLE
Remove unused key

### DIFF
--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -289,7 +289,7 @@ abstract class WP_REST_Controller {
 			return array_merge( $param_details, $args );
 		}
 		$contexts = array();
-		foreach ( $schema['properties'] as $key => $attributes ) {
+		foreach ( $schema['properties'] as $attributes ) {
 			if ( ! empty( $attributes['context'] ) ) {
 				$contexts = array_merge( $contexts, $attributes['context'] );
 			}

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1175,6 +1175,11 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			$data[ $base ] = $terms ? wp_list_pluck( $terms, 'term_id' ) : array();
 		}
 
+		//Remove all data, which is not part of the scheme
+		foreach( $data as $key => $property )
+			if( ! isset( $schema['properties'][ $key ] ) || empty( $schema['properties'][ $key ] ) )
+				unset( $data[ $key ] );
+
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$data = $this->add_additional_fields_to_object( $data, $request );
 		$data = $this->filter_response_by_context( $data, $context );

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -698,7 +698,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			 * Fake the correct cookie to fool post_password_required().
 			 * Without this, get_the_content() will give a password form.
 			 */
-			require_once ABSPATH . 'wp-includes/class-phpass.php';
+			require_once ABSPATH . WPINC .'/class-phpass.php';
 			$hasher = new PasswordHash( 8, true );
 			$value = $hasher->HashPassword( $password );
 			$_COOKIE[ 'wp-postpass_' . COOKIEHASH ] = wp_slash( $value );

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1331,11 +1331,13 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 							'description' => __( 'GUID for the object, as it exists in the database.' ),
 							'type'        => 'string',
 							'context'     => array( 'edit' ),
+							'readonly'    => true,
 						),
 						'rendered' => array(
 							'description' => __( 'GUID for the object, transformed for display.' ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
 						),
 					),
 				),
@@ -1466,6 +1468,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 								'description' => __( 'HTML title for the object, transformed for display.' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit', 'embed' ),
+								'readonly'    => true,
 							),
 						),
 					);
@@ -1486,6 +1489,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 								'description' => __( 'HTML content for the object, transformed for display.' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
 							),
 						),
 					);
@@ -1514,6 +1518,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 								'description' => __( 'HTML excerpt for the object, transformed for display.' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit', 'embed' ),
+								'readonly'    => true,
 							),
 						),
 					);

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -722,6 +722,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		$schema = $this->get_item_schema();
+		#echo json_encode( $schema );die();
 
 		// Post title.
 		if ( ! empty( $schema['properties']['title'] ) && isset( $request['title'] ) ) {
@@ -761,7 +762,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		$post_type = get_post_type_object( $prepared_post->post_type );
 
 		// Post status.
-		if ( isset( $request['status'] ) ) {
+		if ( ! empty( $schema['properties']['status'] ) && isset( $request['status'] ) ) {
 			$status = $this->handle_status_param( $request['status'], $post_type );
 			if ( is_wp_error( $status ) ) {
 				return $status;
@@ -771,13 +772,13 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		// Post date.
-		if ( ! empty( $request['date'] ) ) {
+		if ( ! empty( $schema['properties']['date'] ) && ! empty( $request['date'] ) ) {
 			$date_data = rest_get_date_with_gmt( $request['date'] );
 
 			if ( ! empty( $date_data ) ) {
 				list( $prepared_post->post_date, $prepared_post->post_date_gmt ) = $date_data;
 			}
-		} elseif ( ! empty( $request['date_gmt'] ) ) {
+		} elseif ( ! empty( $schema['properties']['date_gmt'] ) && ! empty( $request['date_gmt'] ) ) {
 			$date_data = rest_get_date_with_gmt( $request['date_gmt'], true );
 
 			if ( ! empty( $date_data ) ) {
@@ -785,7 +786,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			}
 		}
 		// Post slug.
-		if ( isset( $request['slug'] ) ) {
+		if ( ! empty( $schema['properties']['slug'] ) && isset( $request['slug'] ) ) {
 			$prepared_post->post_name = $request['slug'];
 		}
 
@@ -802,7 +803,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		// Post password.
-		if ( isset( $request['password'] ) && '' !== $request['password'] ) {
+		if ( ! empty( $schema['properties']['password'] ) && isset( $request['password'] ) && '' !== $request['password'] ) {
 			$prepared_post->post_password = $request['password'];
 
 			if ( ! empty( $schema['properties']['sticky'] ) && ! empty( $request['sticky'] ) ) {
@@ -814,7 +815,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			}
 		}
 
-		if ( ! empty( $request['sticky'] ) ) {
+		if ( ! empty( $schema['properties']['sticky'] ) && ! empty( $request['sticky'] ) ) {
 			if ( ! empty( $prepared_post->ID ) && post_password_required( $prepared_post->ID ) ) {
 				return new WP_Error( 'rest_invalid_field', __( 'A password protected post can not be set to sticky.' ), array( 'status' => 400 ) );
 			}

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -722,7 +722,6 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		$schema = $this->get_item_schema();
-		#echo json_encode( $schema );die();
 
 		// Post title.
 		if ( ! empty( $schema['properties']['title'] ) && isset( $request['title'] ) ) {

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -513,23 +513,24 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	public function prepare_item_for_database( $request ) {
 		$prepared_term = new stdClass;
 
-		if ( isset( $request['name'] ) ) {
+		$schema = $this->get_item_schema();
+		if ( isset( $request['name'] ) && ! empty( $schema['properties']['name'] ) ) {
 			$prepared_term->name = $request['name'];
 		}
 
-		if ( isset( $request['slug'] ) ) {
+		if ( isset( $request['slug'] ) && ! empty( $schema['properties']['slug'] ) ) {
 			$prepared_term->slug = $request['slug'];
 		}
 
-		if ( isset( $request['taxonomy'] ) ) {
+		if ( isset( $request['taxonomy'] ) && ! empty( $schema['properties']['taxonomy'] ) ) {
 			$prepared_term->taxonomy = $request['taxonomy'];
 		}
 
-		if ( isset( $request['description'] ) ) {
+		if ( isset( $request['description'] ) && ! empty( $schema['properties']['description'] ) ) {
 			$prepared_term->description = $request['description'];
 		}
 
-		if ( isset( $request['parent'] ) ) {
+		if ( isset( $request['parent'] ) && ! empty( $schema['properties']['parent'] ) ) {
 			$parent_term_id = 0;
 			$parent_term = get_term( (int) $request['parent'], $this->taxonomy );
 
@@ -558,16 +559,29 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 
-		$data = array(
-			'id'           => (int) $item->term_id,
-			'count'        => (int) $item->count,
-			'description'  => $item->description,
-			'link'         => get_term_link( $item ),
-			'name'         => $item->name,
-			'slug'         => $item->slug,
-			'taxonomy'     => $item->taxonomy,
-		);
 		$schema = $this->get_item_schema();
+		$data = array();
+		if ( ! empty( $schema['properties']['id'] ) ) {
+			$data['id'] = (int) $item->term_id;
+		}
+		if ( ! empty( $schema['properties']['count'] ) ) {
+			$data['count'] = (int) $item->count;
+		}
+		if ( ! empty( $schema['properties']['description'] ) ) {
+			$data['description'] = $item->description;
+		}
+		if ( ! empty( $schema['properties']['link'] ) ) {
+			$data['link'] = get_term_link( $item );
+		}
+		if ( ! empty( $schema['properties']['name'] ) ) {
+			$data['name'] = $item->name;
+		}
+		if ( ! empty( $schema['properties']['slug'] ) ) {
+			$data['slug'] = $item->slug;
+		}
+		if ( ! empty( $schema['properties']['taxonomy'] ) ) {
+			$data['taxonomy'] = $item->taxonomy;
+		}
 		if ( ! empty( $schema['properties']['parent'] ) ) {
 			$data['parent'] = (int) $item->parent;
 		}

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -82,6 +82,10 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			return new WP_Error( 'rest_user_cannot_view', __( 'Sorry, you cannot filter by role.' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
+		if ( 'edit' === $request['context'] && ! current_user_can( 'list_users' ) ) {
+			return new WP_Error( 'rest_forbidden_context', __( 'Sorry, you cannot view this resource with edit context.' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
 		return true;
 	}
 

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -280,7 +280,9 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			return new WP_Error( 'rest_user_exists', __( 'Cannot create existing resource.' ), array( 'status' => 400 ) );
 		}
 
-		if ( ! empty( $request['roles'] ) ) {
+		$schema = $this->get_item_schema();
+
+		if ( ! empty( $request['roles'] ) && ! empty( $schema['properties']['roles'] ) ) {
 			$check_permission = $this->check_role_update( $request['id'], $request['roles'] );
 			if ( is_wp_error( $check_permission ) ) {
 				return $check_permission;
@@ -314,7 +316,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		}
 
 		$user = get_user_by( 'id', $user_id );
-		if ( ! empty( $request['roles'] ) ) {
+		if ( ! empty( $request['roles'] ) && ! empty( $schema['properties']['roles'] ) ) {
 			array_map( array( $user, 'add_role' ), $request['roles'] );
 		}
 
@@ -494,25 +496,68 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response $response Response data.
 	 */
 	public function prepare_item_for_response( $user, $request ) {
-		$data = array(
-			'id'                 => $user->ID,
-			'username'           => $user->user_login,
-			'name'               => $user->display_name,
-			'first_name'         => $user->first_name,
-			'last_name'          => $user->last_name,
-			'email'              => $user->user_email,
-			'url'                => $user->user_url,
-			'description'        => $user->description,
-			'link'               => get_author_posts_url( $user->ID, $user->user_nicename ),
-			'nickname'           => $user->nickname,
-			'slug'               => $user->user_nicename,
-			'registered_date'    => date( 'c', strtotime( $user->user_registered ) ),
-			'roles'              => $user->roles,
-			'capabilities'       => $user->allcaps,
-			'extra_capabilities' => $user->caps,
-		);
 
+		$data = array();
 		$schema = $this->get_item_schema();
+		if ( ! empty( $schema['properties']['id'] ) ) {
+			$data['id'] = $user->ID;
+		}
+
+		if ( ! empty( $schema['properties']['username'] ) ) {
+			$data['username'] = $user->user_login;
+		}
+
+		if ( ! empty( $schema['properties']['name'] ) ) {
+			$data['name'] = $user->display_name;
+		}
+
+		if ( ! empty( $schema['properties']['first_name'] ) ) {
+			$data['first_name'] = $user->first_name;
+		}
+
+		if ( ! empty( $schema['properties']['last_name'] ) ) {
+			$data['last_name'] = $user->last_name;
+		}
+
+		if ( ! empty( $schema['properties']['email'] ) ) {
+			$data['email'] = $user->user_email;
+		}
+
+		if ( ! empty( $schema['properties']['url'] ) ) {
+			$data['url'] = $user->user_url;
+		}
+
+		if ( ! empty( $schema['properties']['description'] ) ) {
+			$data['description'] = $user->description;
+		}
+
+		if ( ! empty( $schema['properties']['link'] ) ) {
+			$data['link'] = get_author_posts_url( $user->ID, $user->user_nicename );
+		}
+
+		if ( ! empty( $schema['properties']['nickname'] ) ) {
+			$data['nickname'] = $user->nickname;
+		}
+
+		if ( ! empty( $schema['properties']['slug'] ) ) {
+			$data['slug'] = $user->user_nicename;
+		}
+
+		if ( ! empty( $schema['properties']['roles'] ) ) {
+			$data['roles'] = $user->roles;
+		}
+
+		if ( ! empty( $schema['properties']['registered_date'] ) ) {
+			$data['registered_date'] = date( 'c', strtotime( $user->user_registered ) );
+		}
+
+		if ( ! empty( $schema['properties']['capabilities'] ) ) {
+			$data['capabilities'] = $user->allcaps;
+		}
+
+		if ( ! empty( $schema['properties']['extra_capabilities'] ) ) {
+			$data['extra_capabilities'] = $user->caps;
+		}
 
 		if ( ! empty( $schema['properties']['avatar_urls'] ) ) {
 			$data['avatar_urls'] = rest_get_avatar_urls( $user->user_email );
@@ -565,14 +610,16 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 	protected function prepare_item_for_database( $request ) {
 		$prepared_user = new stdClass;
 
+		$schema = $this->get_item_schema();
+
 		// required arguments.
-		if ( isset( $request['email'] ) ) {
+		if ( isset( $request['email'] ) && ! empty( $schema['properties']['email'] ) ) {
 			$prepared_user->user_email = $request['email'];
 		}
-		if ( isset( $request['username'] ) ) {
+		if ( isset( $request['username'] ) && ! empty( $schema['properties']['username'] ) ) {
 			$prepared_user->user_login = $request['username'];
 		}
-		if ( isset( $request['password'] ) ) {
+		if ( isset( $request['password'] ) && ! empty( $schema['properties']['password'] ) ) {
 			$prepared_user->user_pass = $request['password'];
 		}
 
@@ -580,26 +627,26 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		if ( isset( $request['id'] ) ) {
 			$prepared_user->ID = absint( $request['id'] );
 		}
-		if ( isset( $request['name'] ) ) {
+		if ( isset( $request['name'] ) && ! empty( $schema['properties']['name'] ) ) {
 			$prepared_user->display_name = $request['name'];
 		}
-		if ( isset( $request['first_name'] ) ) {
+		if ( isset( $request['first_name'] ) && ! empty( $schema['properties']['first_name'] ) ) {
 			$prepared_user->first_name = $request['first_name'];
 		}
-		if ( isset( $request['last_name'] ) ) {
+		if ( isset( $request['last_name'] ) && ! empty( $schema['properties']['last_name'] ) ) {
 			$prepared_user->last_name = $request['last_name'];
 		}
-		if ( isset( $request['nickname'] ) ) {
+		if ( isset( $request['nickname'] ) && ! empty( $schema['properties']['nickname'] ) ) {
 			$prepared_user->nickname = $request['nickname'];
 		}
-		if ( isset( $request['slug'] ) ) {
+		if ( isset( $request['slug'] ) && ! empty( $schema['properties']['slug'] ) ) {
 			$prepared_user->user_nicename = $request['slug'];
 		}
-		if ( isset( $request['description'] ) ) {
+		if ( isset( $request['description'] ) && ! empty( $schema['properties']['description'] ) ) {
 			$prepared_user->description = $request['description'];
 		}
 
-		if ( isset( $request['url'] ) ) {
+		if ( isset( $request['url'] ) && ! empty( $schema['properties']['url'] ) ) {
 			$prepared_user->user_url = $request['url'];
 		}
 

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -770,6 +770,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 					'description' => __( 'All capabilities assigned to the resource.' ),
 					'type'        => 'object',
 					'context'     => array( 'edit' ),
+					'readonly'    => true,
 				),
 				'extra_capabilities' => array(
 					'description' => __( 'Any extra capabilities assigned to the resource.' ),

--- a/plugin.php
+++ b/plugin.php
@@ -299,6 +299,10 @@ if ( ! function_exists( 'rest_validate_request_arg' ) ) {
 			return new WP_Error( 'rest_invalid_param', sprintf( __( '%s is not of type %s' ), $param, 'integer' ) );
 		}
 
+		if ( 'boolean' === $args['type'] && ! is_bool( $value ) ) {
+			return new WP_Error( 'rest_invalid_param', sprintf( __( '%s is not of type %s' ), $param, 'boolean' ) );
+		}
+
 		if ( 'string' === $args['type'] && ! is_string( $value ) ) {
 			return new WP_Error( 'rest_invalid_param', sprintf( __( '%s is not of type %s' ), $param, 'string' ) );
 		}

--- a/tests/test-rest-controller.php
+++ b/tests/test-rest-controller.php
@@ -9,6 +9,9 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 				'someinteger'     => array(
 					'type'        => 'integer',
 				),
+				'someboolean'     => array(
+					'type'        => 'boolean',
+				),
 				'somestring'      => array(
 					'type'        => 'string',
 				),
@@ -37,6 +40,25 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 		$this->assertErrorResponse(
 			'rest_invalid_param',
 			rest_validate_request_arg( 'abc', $this->request, 'someinteger' )
+		);
+	}
+
+	public function test_validate_schema_type_boolean() {
+
+		$this->assertTrue(
+			rest_validate_request_arg( true, $this->request, 'someboolean' )
+		);
+		$this->assertTrue(
+			rest_validate_request_arg( false, $this->request, 'someboolean' )
+		);
+
+		$this->assertErrorResponse(
+			'rest_invalid_param',
+			rest_validate_request_arg( 'true', $this->request, 'someboolean' )
+		);
+		$this->assertErrorResponse(
+			'rest_invalid_param',
+			rest_validate_request_arg( '123', $this->request, 'someboolean' )
 		);
 	}
 


### PR DESCRIPTION
I run phpmd, and find following notification.

```
/var/www/wordpress/wp-content/plugins/rest-api/lib/endpoints/class-wp-rest-controller.php:292Avoid unused local variables such as ''.
```

So, I removed  parameter.
thanks.
